### PR TITLE
catch JSON parse error

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -395,7 +395,7 @@ app.enableAuth = function(options) {
                 ctx.args.filter = JSON.parse(ctx.args.filter);
               } catch (error) {
                 errStatusCode = 400;
-                var e = new SyntaxError(messages[errStatusCode].message + ' Invalid JSON');
+                var e = new SyntaxError(messages[errStatusCode].message);
                 e.status = e.statusCode = errStatusCode;
                 e.code = messages[errStatusCode].code;
                 next(e);

--- a/lib/application.js
+++ b/lib/application.js
@@ -364,6 +364,25 @@ app.enableAuth = function(options) {
         method,
         ctx,
         function(err, allowed, propertyACLs) {
+          var messages = {
+            403: {
+              message: 'Access Denied',
+              code: 'ACCESS_DENIED'
+            },
+            404: {
+              message: ('could not find ' + modelName + ' with id ' + modelId),
+              code: 'MODEL_NOT_FOUND'
+            },
+            401: {
+              message: 'Authorization Required',
+              code: 'AUTHORIZATION_REQUIRED'
+            },
+            400: {
+              message: 'Bad Request',
+              code: 'BAD_REQUEST'
+            }
+          };
+
           if (err) {
             console.log(err);
             next(err);
@@ -375,8 +394,10 @@ app.enableAuth = function(options) {
               try {
                 ctx.args.filter = JSON.parse(ctx.args.filter);
               } catch (error) {
-                var e = new SyntaxError('Bad request: Invalid JSON.');
-                e.status = e.statusCode = 400;
+                errStatusCode = 400;
+                var e = new SyntaxError(messages[errStatusCode].message + ' Invalid JSON');
+                e.status = e.statusCode = errStatusCode;
+                e.code = messages[errStatusCode].code;
                 next(e);
                 return;
               }
@@ -392,21 +413,6 @@ app.enableAuth = function(options) {
             }, ctx.args.filter.fields);
             next();
           } else {
-
-            var messages = {
-              403: {
-                message: 'Access Denied',
-                code: 'ACCESS_DENIED'
-              },
-              404: {
-                message: ('could not find ' + modelName + ' with id ' + modelId),
-                code: 'MODEL_NOT_FOUND'
-              },
-              401: {
-                message: 'Authorization Required',
-                code: 'AUTHORIZATION_REQUIRED'
-              }
-            };
 
             var e = new Error(messages[errStatusCode].message || messages[403].message);
             e.statusCode = errStatusCode;

--- a/lib/application.js
+++ b/lib/application.js
@@ -372,7 +372,14 @@ app.enableAuth = function(options) {
               ctx.args.filter = { fields: {} };
             }
             if (typeof ctx.args.filter === 'string') {
-              ctx.args.filter = JSON.parse(ctx.args.filter);
+              try {
+                ctx.args.filter = JSON.parse(ctx.args.filter);
+              } catch (error) {
+                var e = new Error('Bad request: Invalid JSON.');
+                e.statusCode = 400;
+                next(e);
+                return;
+              }
             }
             if (!ctx.args.filter.fields) {
               ctx.args.filter.fields = {};

--- a/lib/application.js
+++ b/lib/application.js
@@ -375,8 +375,8 @@ app.enableAuth = function(options) {
               try {
                 ctx.args.filter = JSON.parse(ctx.args.filter);
               } catch (error) {
-                var e = new Error('Bad request: Invalid JSON.');
-                e.statusCode = 400;
+                var e = new SyntaxError('Bad request: Invalid JSON.');
+                e.status = e.statusCode = 400;
                 next(e);
                 return;
               }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neaty",
-  "version": "2.29.5",
+  "version": "2.29.6",
   "description": "Neaty: Open Source Framework for Node.js",
   "homepage": "https://neaty.io",
   "keywords": [


### PR DESCRIPTION
Bug: when client pass invalid json argument to server, the server will break down. 

Fix: add `try...catch` block outside JSON parse.

when i test in curl with query as below

```
filter={where: {"userId": "hehe"}}
```

server will respond like below

```
{"error":{"name":"Error","status":400,"message":"Bad request: Invalid JSON.","statusCode":400}}
```

R= @yorkie  please review, thank you.
